### PR TITLE
Fixing asa_vault contract issue for Python Challenge 3.

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -21,6 +21,14 @@ class AsaVault(ARC4Contract):
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
+
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            sender=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
         
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 

--- a/projects/challenge/smart_contracts/asa_vault/deploy_config.py
+++ b/projects/challenge/smart_contracts/asa_vault/deploy_config.py
@@ -63,6 +63,7 @@ def deploy(
     sp.fee = 2000
     sp.flat_fee = True
 
+    print(f"Attempting to opt into asset: {created_asset}")
     app_client.opt_in_to_asset(mbr_pay=TransactionWithSigner(mbr_pay, deployer.signer), transaction_parameters= algokit_utils.TransactionParameters(
         foreign_assets=[created_asset],
         suggested_params=sp
@@ -77,6 +78,7 @@ def deploy(
         index=created_asset,
     )
 
+    print(f"Attempting to deposit asset: {created_asset}")
     app_client.deposit_asa(deposit_txn=TransactionWithSigner(deposit_txn, deployer.signer))
 
     # Check the balance of the vault


### PR DESCRIPTION
What was the problem?

The application needed to be opted into the asset before it could be stored.

How did you solve the problem?

Using an inner transaction to opt the contract into the asset.

Screenshot of your terminal showing the result of running the deploy script.

![image](https://github.com/algorand-coding-challenges/python-challenge-3/assets/126304247/3535f4c2-45f0-4f42-a925-9eccc80e3d48)

