### PR TITLE
Fix: issue with optin function

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -19,6 +19,14 @@ class AsaVault(ARC4Contract):
         self.authorize_creator()
         assert not Global.current_application_address.is_opted_in(Asset(self.asset_id))
 
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+            sender=Global.current_application_address,
+            fee=0,
+        ).submit()
+        
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
         


### PR DESCRIPTION
What was the problem?

The contract failed because of the application didn't opt in to the asset

How did you solve the problem?

Update the op_in_to_asset() method and add an innerTxn with an AssetTransfer to the application itself in order to optin to the asset.

![image](https://github.com/algorand-coding-challenges/python-challenge-3/assets/5107647/210e4c6f-5f06-4fb1-85c4-17ecd7c07653)
