### PR TITLE
Solution

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -22,6 +22,14 @@ class AsaVault(ARC4Contract):
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
         
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            sender=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
+
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 
         self.authorize_creator()


### PR DESCRIPTION
**What was the problem?**

The error stated that the asset wasn't opted in. 

**How did you solve the problem?**

According to the documentation, if a smart contract wishes to transfer an asset it holds or needs to opt into an asset this can be done with an asset transfer inner transaction. So I added the transaction to ```opt_in_to_asset.```

**Screenshot of your terminal showing the result of running the deploy script.**

![image](https://github.com/algorand-coding-challenges/python-challenge-3/assets/63990513/4bc6b3c5-aa7f-4890-a31e-24b24986fa63)
