### PR TITLE
Add AssetTransfer transaction to facilitate opt-in.

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -22,6 +22,13 @@ class AsaVault(ARC4Contract):
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
         
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
+
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 
         self.authorize_creator()


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Got Error: TransactionPool.Remember: transaction <>: receiver error: must optin, asset 1011 missing from <>

**How did you fix the bug?**

Add AssetTransfer function to smart-contract.

**Console Screenshot:**

![Screenshot 2567-04-17 at 15 51 51](https://github.com/algorand-coding-challenges/python-challenge-3/assets/3756229/dd58b6b0-a316-46f1-85ea-53e5b2d9e2d7)
