### PR TITLE
Fix: Add missing optin transaction

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -1,4 +1,4 @@
-from algopy import ARC4Contract, arc4, UInt64, Asset, gtxn, itxn, Txn, Global,subroutine
+from algopy import ARC4Contract, arc4, UInt64, Asset, gtxn, itxn, Txn, Global, subroutine
 
 class AsaVault(ARC4Contract):
     asset_id: UInt64
@@ -21,6 +21,12 @@ class AsaVault(ARC4Contract):
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
+
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0
+        ).submit()
         
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 

--- a/projects/challenge/smart_contracts/asa_vault/deploy_config.py
+++ b/projects/challenge/smart_contracts/asa_vault/deploy_config.py
@@ -63,13 +63,15 @@ def deploy(
     sp.fee = 2000
     sp.flat_fee = True
 
-    app_client.opt_in_to_asset(mbr_pay=TransactionWithSigner(mbr_pay, deployer.signer), transaction_parameters= algokit_utils.TransactionParameters(
-        foreign_assets=[created_asset],
-        suggested_params=sp
+    app_client.opt_in_to_asset(
+        mbr_pay=TransactionWithSigner(mbr_pay, deployer.signer), 
+        transaction_parameters=algokit_utils.TransactionParameters(
+            foreign_assets=[created_asset],
+            suggested_params=sp
     ))
 
     # Deposit the ASA into the vault
-    deposit_txn  = transaction.AssetTransferTxn(
+    deposit_txn = transaction.AssetTransferTxn(
         sender=deployer.address,
         sp=sp,
         receiver=app_client.app_address,


### PR DESCRIPTION
**What was the bug?**
The smart contract's optin method was missing the actual inner transaction that could have opted in the application to store the given asset.

This thrown the following error:
```bash
/home/algorambo/.local/bin/poetry: algosdk.error.AlgodHTTPError: 
TransactionPool.Remember: transaction FPFNUZMAUZMEH6M2XLA6XE7CJAWHKACEUMXX2XKKS677SV2DS3RA: 
receiver error: must optin, asset 1030 missing from JN2K75SCE6NXD4F3OJREI7AZMPPPY5ORGPF3UAFOVGEGGC7TRKDX4LMCXM
```

Full error log:
```bash
Using deploy command: /home/algorambo/.local/bin/poetry run python -m smart_contracts deploy
Loading deployment environment variables...
Deploying smart contracts from AlgoKit compliant repository 🚀
/home/algorambo/.local/bin/poetry: 2024-04-17 18:55:06,097 INFO      : Loading .env
/home/algorambo/.local/bin/poetry: 2024-04-17 18:55:06,097 INFO      : Deploying app asa_vault
/home/algorambo/.local/bin/poetry: 2024-04-17 18:55:06,917 INFO      : An error occurred while executing the transaction.
/home/algorambo/.local/bin/poetry: 2024-04-17 18:55:06,917 INFO      : To see more details, enable debug mode by setting config.debug = True
/home/algorambo/.local/bin/poetry: Traceback (most recent call last):
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/v2client/algod.py", line 104, in algod_request
/home/algorambo/.local/bin/poetry: resp = urlopen(req)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 215, in urlopen
/home/algorambo/.local/bin/poetry: return opener.open(url, data, timeout)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 521, in open
/home/algorambo/.local/bin/poetry: response = meth(req, response)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 630, in http_response
/home/algorambo/.local/bin/poetry: response = self.parent.error(
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 559, in error
/home/algorambo/.local/bin/poetry: return self._call_chain(*args)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 492, in _call_chain
/home/algorambo/.local/bin/poetry: result = func(*args)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/usr/lib/python3.12/urllib/request.py", line 639, in http_error_default
/home/algorambo/.local/bin/poetry: raise HTTPError(req.full_url, code, msg, hdrs, fp)
/home/algorambo/.local/bin/poetry: urllib.error.HTTPError: HTTP Error 400: Bad Request
/home/algorambo/.local/bin/poetry: 
/home/algorambo/.local/bin/poetry: During handling of the above exception, another exception occurred:
/home/algorambo/.local/bin/poetry: 
/home/algorambo/.local/bin/poetry: Traceback (most recent call last):
/home/algorambo/.local/bin/poetry: File "<frozen runpy>", line 198, in _run_module_as_main
/home/algorambo/.local/bin/poetry: File "<frozen runpy>", line 88, in _run_code
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/smart_contracts/__main__.py", line 56, in <module>
/home/algorambo/.local/bin/poetry: main(sys.argv[1])
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/smart_contracts/__main__.py", line 44, in main
/home/algorambo/.local/bin/poetry: deploy(app_spec_path, contract.deploy)
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/smart_contracts/helpers/deploy.py", line 53, in deploy
/home/algorambo/.local/bin/poetry: deploy_callback(algod_client, indexer_client, app_spec, deployer)
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/smart_contracts/asa_vault/deploy_config.py", line 80, in deploy
/home/algorambo/.local/bin/poetry: app_client.deposit_asa(deposit_txn=TransactionWithSigner(deposit_txn, deployer.signer))
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/smart_contracts/artifacts/asa_vault/client.py", line 603, in deposit_asa
/home/algorambo/.local/bin/poetry: result = self.app_client.call(
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algokit_utils/application_client.py", line 645, in call
/home/algorambo/.local/bin/poetry: return self._execute_atc_tr(atc)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algokit_utils/application_client.py", line 1164, in _execute_atc_tr
/home/algorambo/.local/bin/poetry: result = self.execute_atc(atc)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algokit_utils/application_client.py", line 1168, in execute_atc
/home/algorambo/.local/bin/poetry: return execute_atc_with_logic_error(
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algokit_utils/application_client.py", line 1317, in execute_atc_with_logic_error
/home/algorambo/.local/bin/poetry: raise ex
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algokit_utils/application_client.py", line 1295, in execute_atc_with_logic_error
/home/algorambo/.local/bin/poetry: return atc.execute(algod_client, wait_rounds=wait_rounds)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/atomic_transaction_composer.py", line 862, in execute
/home/algorambo/.local/bin/poetry: self.submit(client)
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/atomic_transaction_composer.py", line 725, in submit
/home/algorambo/.local/bin/poetry: client.send_transactions(self.signed_txns)
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/v2client/algod.py", line 430, in send_transactions
/home/algorambo/.local/bin/poetry: return self.send_raw_transaction(
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/v2client/algod.py", line 358, in send_raw_transaction
/home/algorambo/.local/bin/poetry: resp = self.algod_request("POST", req, data=txn_bytes, **kwargs)
/home/algorambo/.local/bin/poetry: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/algorambo/.local/bin/poetry: File "/home/algorambo/developments/algorand-challenges/python-challenge-3/projects/challenge/.venv/lib/python3.12/site-packages/algosdk/v2client/algod.py", line 111, in algod_request
/home/algorambo/.local/bin/poetry: raise error.AlgodHTTPError(e, code)
/home/algorambo/.local/bin/poetry: algosdk.error.AlgodHTTPError: TransactionPool.Remember: transaction FPFNUZMAUZMEH6M2XLA6XE7CJAWHKACEUMXX2XKKS677SV2DS3RA: receiver error: must optin, asset 1030 missing from JN2K75SCE6NXD4F3OJREI7AZMPPPY5ORGPF3UAFOVGEGGC7TRKDX4LMCXM
/home/algorambo/.local/bin/poetry: The Super RARE Oranges is created and has asset id: 1030
/home/algorambo/.local/bin/poetry: Created app with app id: 1031
Error: Deployment command exited with error code = 1
```

**How did you fix the bug?**
Added an optin inner transaction into the ``opt_in_to_asset()`` method under the ``contract.py``:
```python
@arc4.abimethod
def opt_in_to_asset(self, mbr_pay: gtxn.PaymentTransaction) -> None:
   # existing code...

   itxn.AssetTransfer(
      xfer_asset=self.asset_id,
      asset_receiver=Global.current_application_address,
      asset_amount=0
   ).submit()
```

**Console Screenshot:**
<img width="589" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-3/assets/162426140/126ecc13-907b-405e-a19b-35502f1c9001">

