### PR TITLE
Python Challenge 3 Completed

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -21,7 +21,14 @@ class AsaVault(ARC4Contract):
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
-        
+
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+            fee=0
+        ).submit()
+
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 
         self.authorize_creator()
@@ -47,4 +54,3 @@ class AsaVault(ARC4Contract):
     @arc4.abimethod(readonly=True)
     def get_asa_balance(self) -> UInt64:
         return self.asa_balance
-        


### PR DESCRIPTION
1. The problem is there was no actual transaction to opt in to the asa in the function opt_in_to_asset().  You can see a proper transaction written within the withdraw_asa() function.

2. By adding an inner transaction (itxn) with the AssetTransfer() method, we call xfer_asset=self.asset_id and asset_receiver=Global.current_application_address to ensure we're opted in to the ASA.

3. 
![image](https://github.com/algorand-coding-challenges/python-challenge-3/assets/57732382/6af7cf37-fa93-4062-9ddb-637b4116dd6c)
