### PR TITLE
[fix] Missing asset optin transaction in contract

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -21,6 +21,13 @@ class AsaVault(ARC4Contract):
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
+
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
         
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 


### PR DESCRIPTION
---- The bug ----

When calling deposit_asa method, the contract account has not opted in the Super RARE Oranges asa, so it can't receive it.

---- The fix ----

The deployment script call the opt_in_to_asset method, so it's the method that doesn't do its job.
I added an inner transaction of type AssetTransfer from the contract account to itself to optin to the asa in the method body.

---- The screenshot ----

![image](https://github.com/algorand-coding-challenges/python-challenge-3/assets/162464577/91d738b9-7881-4cb2-a4b7-390e739f8569)
