### PR TITLE
Fix asset opt-in method

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -21,7 +21,14 @@ class AsaVault(ARC4Contract):
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
-        
+
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
+
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 
         self.authorize_creator()
@@ -47,4 +54,3 @@ class AsaVault(ARC4Contract):
     @arc4.abimethod(readonly=True)
     def get_asa_balance(self) -> UInt64:
         return self.asa_balance
-        


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Missing inner transaction in `opt_in_to_asset()` method of `AsaVault` contract breaks deployment checks.

**How did you fix the bug?**

The bug was fixed by adding asset opt-in zero-value inner transfer to `opt_in_to_asset()` method.

**Console Screenshot:**
![python_challenge_3](https://github.com/algorand-coding-challenges/python-challenge-3/assets/114208957/c545cbd7-6533-43fa-a85f-a889db12e896)
