### PR TITLE
python-challenge-3 solved

### DIFF
--- a/projects/challenge/smart_contracts/asa_vault/contract.py
+++ b/projects/challenge/smart_contracts/asa_vault/contract.py
@@ -18,10 +18,17 @@ class AsaVault(ARC4Contract):
     def opt_in_to_asset(self, mbr_pay: gtxn.PaymentTransaction) -> None:
         self.authorize_creator()
         assert not Global.current_application_address.is_opted_in(Asset(self.asset_id))
+        itxn.AssetTransfer(
+            xfer_asset=self.asset_id,
+            asset_receiver=Global.current_application_address,
+            sender=Global.current_application_address,
+            asset_amount=0,
+            fee=0,
+        ).submit()
 
         assert mbr_pay.receiver == Global.current_application_address
         assert mbr_pay.amount == Global.min_balance + Global.asset_opt_in_min_balance
-        
+
     @arc4.abimethod
     def deposit_asa(self, deposit_txn: gtxn.AssetTransferTransaction)-> None: 
         self.authorize_creator()
@@ -47,4 +54,3 @@ class AsaVault(ARC4Contract):
     @arc4.abimethod(readonly=True)
     def get_asa_balance(self) -> UInt64:
         return self.asa_balance
-        


### PR DESCRIPTION
What was the bug ?
The issue surfaced because the opt-in transaction for the application wasn't encompassed within the opt_in_to_asset method of the contract.
How did you solve?
A new opt-in transaction has been created and seamlessly incorporated into the opt_in_to_asset method of the contract.
![A-py-3](https://github.com/algorand-coding-challenges/python-challenge-3/assets/121881902/0651039f-cbb7-4d32-9a1b-d9d8d5940cad)
